### PR TITLE
add clean command for npm

### DIFF
--- a/clean.js
+++ b/clean.js
@@ -1,0 +1,12 @@
+const fs = require('node:fs/promises')  
+async function main () {  
+  const files = await fs.readdir('.');
+  for (const file of files) {
+    if (file.startsWith('ghostpdl-') && file.endsWith('.tar.gz')) {
+      await fs.unlink(file);
+    } else if (file === 'ghostpdl') {
+      await fs.rm(file, { recursive: true, force: true });
+    }
+  }
+}  
+main().catch(err => console.error(err)) 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "clean": "rm -rf ghostpd*"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "clean": "rm -rf ghostpd*"
+    "clean": "node clean.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

This PR adds the possibility to use clean with npm and remove all previous  attempt to download and fetch the source code
 
## Validation

```js

"scripts": {
    "start": "node index.js",
    "clean": "rm -rf ghostpd*" // <-- This command removes the tar archive and the build directory
  },
```